### PR TITLE
Deduplicate multiple ingresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 bin/
 command
 testing
+ca
+config
+envoy

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testing
 ca
 config
 envoy
+launch.json

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Yggdrasil allows for some customisation of the route and cluster config per Ingr
 | Name                                                         | type     |
 |--------------------------------------------------------------|----------|
 | [yggdrasil.uswitch.com/healthcheck-path](#health-check-path) | string   |
+| [yggdrasil.uswitch.com/healthcheck-host](#health-check-host) | string   |
 | [yggdrasil.uswitch.com/timeout](#timeouts)                   | duration |
 | [yggdrasil.uswitch.com/cluster-timeout](#timeouts)           | duration |
 | [yggdrasil.uswitch.com/route-timeout](#timeouts)             | duration |
@@ -84,6 +85,9 @@ Yggdrasil allows for some customisation of the route and cluster config per Ingr
 
 ### Health Check Path
 Specifies a path to configure a [HTTP health check](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/core/v3/health_check.proto#config-core-v3-healthcheck-httphealthcheck) to. Envoy will not route to clusters that fail health checks.
+
+### Health Check Host
+Permit to change the host of the healthcheck when using wildcard. Example: healthcheck for `*.my-app.example.com` can't work natively, you can configure a specific path with `yggdrasil.uswitch.com/healthcheck-host: health.my-app.example.com`.
 
 * [config.core.v3.HealthCheck.HttpHealthCheck.Path](https://www.envoyproxy.io/docs/envoy/v1.19.0/api-v3/config/core/v3/health_check.proto#envoy-v3-api-field-config-core-v3-healthcheck-httphealthcheck-path)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -214,12 +213,12 @@ func main(*cobra.Command, []string) error {
 		certPath := certificate.Cert
 		keyPath := certificate.Key
 
-		certBytes, err := ioutil.ReadFile(certPath)
+		certBytes, err := os.ReadFile(certPath)
 		if err != nil {
 			log.Fatalf("Failed to read %s: %v", certPath, err)
 		}
 
-		keyBytes, err := ioutil.ReadFile(keyPath)
+		keyBytes, err := os.ReadFile(keyPath)
 		if err != nil {
 			log.Fatalf("Failed to read %s: %v", keyPath, err)
 		}
@@ -286,7 +285,7 @@ func createSources(clusters []clusterConfig) ([]*kubernetes.Clientset, error) {
 		var token string
 
 		if cluster.TokenPath != "" {
-			bytes, err := ioutil.ReadFile(cluster.TokenPath)
+			bytes, err := os.ReadFile(cluster.TokenPath)
 			if err != nil {
 				return sources, err
 			}

--- a/launch.json
+++ b/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "main.go",
+            "args": ["--config=./config/config.json",
+             "--upstream-port=443",
+              "--ca=/etc/ssl/certs/",
+               "--envoy-port=443",
+                "--envoy-listener-ipv4-address=127.0.0.1",
+                 "--max-ejection-percentage=100",
+                  "--retry-on", "connect-failure,5xx"]
+        }
+    ]
+}

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -440,7 +440,7 @@ func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPer
 		}
 	}
 
-	healthChecks := makeHealthChecks(c.VirtualHost, c.HealthCheckPath, healthCfg)
+	healthChecks := makeHealthChecks(c.HealthCheckHost, c.HealthCheckPath, healthCfg)
 
 	endpoints := make([]*endpoint.LbEndpoint, len(addresses))
 


### PR DESCRIPTION
@Aluxima @Solvik 

Here are the two fixes : 

- upstream deduplications
- annotation that permit to override the healthcheck host for wildcard only