### PR TITLE
feat(aggregator.go): adding a warn log when err is not nil

### DIFF
--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -96,6 +96,8 @@ func getIngressInformer(factory informers.SharedInformerFactory, clientSet *kube
 	for _, apiGroup := range []string{"networking.k8s.io/v1", "networking.k8s.io/v1beta1", "extensions/v1beta1"} {
 		resources, err := clientSet.ServerResourcesForGroupVersion(apiGroup)
 		if err != nil {
+			// Log to tell earlier if the token have a problem
+			logrus.Warnf("API group %s not available: %v", apiGroup, err)
 			continue
 		}
 		for _, rs := range resources.APIResources {


### PR DESCRIPTION
@Aluxima 

Adding a warn log when err isn't nil. Cause it can be just because your token is incorrect and the only error you have is "panic: runtime error: invalid memory address or nil pointer dereference" 