### PR TITLE
feat: refactor CA certificate handling to use byte arrays

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -240,7 +240,7 @@ func main(*cobra.Command, []string) error {
 		c.Certificates[idx].Key = string(keyBytes)
 	}
 	aggregator := k8s.NewAggregator(sources, ctx, c.SyncSecrets)
-	configurator := envoy.NewKubernetesConfigurator(
+	configurator, err := envoy.NewKubernetesConfigurator(
 		viper.GetString("nodeName"),
 		c.Certificates,
 		viper.GetString("trustCA"),
@@ -262,6 +262,9 @@ func main(*cobra.Command, []string) error {
 		envoy.WithTracingProvider(viper.GetString("tracingProvider")),
 		envoy.WithAlpnProtocols(viper.GetStringSlice("alpnProtocols")),
 	)
+	if err != nil {
+		return fmt.Errorf("error creating configurator: %w", err)
+	}
 	configurator.ValidateAndFormatPath()
 	snapshotter := envoy.NewSnapshotter(envoyCache, configurator, aggregator)
 

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -468,15 +468,15 @@ func makeHealthChecks(upstreamVHost string, healthPath string, config UpstreamHe
 	return healthChecks
 }
 
-func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPercentage int32, addresses []*core.Address) *v3cluster.Cluster {
+func makeCluster(c cluster, caBytes []byte, healthCfg UpstreamHealthCheck, outlierPercentage int32, addresses []*core.Address) *v3cluster.Cluster {
 
 	tls := &auth.UpstreamTlsContext{}
-	if ca != "" {
+	if len(caBytes) > 0 {
 		tls.CommonTlsContext = &auth.CommonTlsContext{
 			ValidationContextType: &auth.CommonTlsContext_ValidationContext{
 				ValidationContext: &auth.CertificateValidationContext{
 					TrustedCa: &core.DataSource{
-						Specifier: &core.DataSource_Filename{Filename: ca},
+						Specifier: &core.DataSource_InlineBytes{InlineBytes: caBytes},
 					},
 				},
 			},

--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -481,6 +481,9 @@ func makeCluster(c cluster, caBytes []byte, healthCfg UpstreamHealthCheck, outli
 				},
 			},
 		}
+		if !strings.HasPrefix(c.VirtualHost, "*.") {
+			tls.Sni = c.VirtualHost
+		}
 	} else {
 		tls = nil
 	}
@@ -506,15 +509,22 @@ func makeCluster(c cluster, caBytes []byte, healthCfg UpstreamHealthCheck, outli
 		}
 	}
 
+	commonHttpOpts := &core.HttpProtocolOptions{
+		IdleTimeout:              &duration.Duration{Seconds: 60},
+		MaxConnectionDuration:    &durationpb.Duration{Seconds: 60},
+		MaxRequestsPerConnection: &wrapperspb.UInt32Value{Value: 10000},
+	}
+	upstreamHttpOpts := &core.UpstreamHttpProtocolOptions{
+		AutoSni:           true,
+		AutoSanValidation: true,
+	}
+
 	var httpOptions *envoy_extension_http.HttpProtocolOptions
 	if c.HttpVersion == "1.1" {
 
 		httpOptions = &envoy_extension_http.HttpProtocolOptions{
-			CommonHttpProtocolOptions: &core.HttpProtocolOptions{
-				IdleTimeout:              &duration.Duration{Seconds: 60},
-				MaxConnectionDuration:    &durationpb.Duration{Seconds: 60},
-				MaxRequestsPerConnection: &wrapperspb.UInt32Value{Value: 10000},
-			},
+			CommonHttpProtocolOptions:  commonHttpOpts,
+			UpstreamHttpProtocolOptions: upstreamHttpOpts,
 			UpstreamProtocolOptions: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig_{
 				ExplicitHttpConfig: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig{
 					ProtocolConfig: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{
@@ -525,11 +535,8 @@ func makeCluster(c cluster, caBytes []byte, healthCfg UpstreamHealthCheck, outli
 		}
 	} else { // TODO be more specific, handle default version
 		httpOptions = &envoy_extension_http.HttpProtocolOptions{
-			CommonHttpProtocolOptions: &core.HttpProtocolOptions{
-				IdleTimeout:              &duration.Duration{Seconds: 60},
-				MaxConnectionDuration:    &durationpb.Duration{Seconds: 60},
-				MaxRequestsPerConnection: &wrapperspb.UInt32Value{Value: 10000},
-			},
+			CommonHttpProtocolOptions:  commonHttpOpts,
+			UpstreamHttpProtocolOptions: upstreamHttpOpts,
 			UpstreamProtocolOptions: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig_{
 				ExplicitHttpConfig: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig{
 					ProtocolConfig: &envoy_extension_http.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -8,6 +8,8 @@ import (
 
 	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	eal "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	envoy_extension_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes/duration"
 )
 
@@ -97,6 +99,126 @@ func TestAccessLoggerConfig(t *testing.T) {
 				t.Errorf("Log format map should match configuration")
 			}
 		})
+	}
+}
+
+func TestMakeClusterSNISetForNonWildcard(t *testing.T) {
+	caBytes := []byte("fake-ca-cert")
+	c := cluster{
+		Name:        "example_com",
+		VirtualHost: "example.com",
+		Hosts:       []LBHost{{Host: "10.0.0.1", Weight: 1}},
+		Timeout:     5 * time.Second,
+	}
+	addresses := makeAddresses(c.Hosts, 443)
+	result := makeCluster(c, caBytes, UpstreamHealthCheck{}, -1, addresses)
+
+	if result.TransportSocket == nil {
+		t.Fatal("Expected TransportSocket to be set when caBytes provided")
+	}
+
+	tlsContext := &auth.UpstreamTlsContext{}
+	if err := result.TransportSocket.GetTypedConfig().UnmarshalTo(tlsContext); err != nil {
+		t.Fatalf("Failed to unmarshal UpstreamTlsContext: %s", err)
+	}
+
+	if tlsContext.Sni != "example.com" {
+		t.Errorf("Expected SNI to be 'example.com', got '%s'", tlsContext.Sni)
+	}
+}
+
+func TestMakeClusterSNINotSetForWildcard(t *testing.T) {
+	caBytes := []byte("fake-ca-cert")
+	c := cluster{
+		Name:        "wildcard_example_com",
+		VirtualHost: "*.example.com",
+		Hosts:       []LBHost{{Host: "10.0.0.1", Weight: 1}},
+		Timeout:     5 * time.Second,
+	}
+	addresses := makeAddresses(c.Hosts, 443)
+	result := makeCluster(c, caBytes, UpstreamHealthCheck{}, -1, addresses)
+
+	tlsContext := &auth.UpstreamTlsContext{}
+	if err := result.TransportSocket.GetTypedConfig().UnmarshalTo(tlsContext); err != nil {
+		t.Fatalf("Failed to unmarshal UpstreamTlsContext: %s", err)
+	}
+
+	if tlsContext.Sni != "" {
+		t.Errorf("Expected SNI to be empty for wildcard host, got '%s'", tlsContext.Sni)
+	}
+}
+
+func TestMakeClusterNoTLSWithoutCA(t *testing.T) {
+	c := cluster{
+		Name:        "example_com",
+		VirtualHost: "example.com",
+		Hosts:       []LBHost{{Host: "10.0.0.1", Weight: 1}},
+		Timeout:     5 * time.Second,
+	}
+	addresses := makeAddresses(c.Hosts, 443)
+	result := makeCluster(c, nil, UpstreamHealthCheck{}, -1, addresses)
+
+	if result.TransportSocket != nil {
+		t.Error("Expected TransportSocket to be nil when no caBytes provided")
+	}
+}
+
+func TestMakeClusterAutoSniEnabled(t *testing.T) {
+	c := cluster{
+		Name:        "example_com",
+		VirtualHost: "example.com",
+		Hosts:       []LBHost{{Host: "10.0.0.1", Weight: 1}},
+		Timeout:     5 * time.Second,
+	}
+	addresses := makeAddresses(c.Hosts, 443)
+	result := makeCluster(c, []byte("fake-ca"), UpstreamHealthCheck{}, -1, addresses)
+
+	httpOptionsPb, ok := result.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+	if !ok {
+		t.Fatal("Expected HttpProtocolOptions in TypedExtensionProtocolOptions")
+	}
+
+	httpOptions := &envoy_extension_http.HttpProtocolOptions{}
+	if err := httpOptionsPb.UnmarshalTo(httpOptions); err != nil {
+		t.Fatalf("Failed to unmarshal HttpProtocolOptions: %s", err)
+	}
+
+	if httpOptions.UpstreamHttpProtocolOptions == nil {
+		t.Fatal("Expected UpstreamHttpProtocolOptions to be set")
+	}
+	if !httpOptions.UpstreamHttpProtocolOptions.AutoSni {
+		t.Error("Expected AutoSni to be true")
+	}
+	if !httpOptions.UpstreamHttpProtocolOptions.AutoSanValidation {
+		t.Error("Expected AutoSanValidation to be true")
+	}
+}
+
+func TestMakeClusterAutoSniWithHTTP2(t *testing.T) {
+	c := cluster{
+		Name:        "example_com",
+		VirtualHost: "example.com",
+		HttpVersion: "2",
+		Hosts:       []LBHost{{Host: "10.0.0.1", Weight: 1}},
+		Timeout:     5 * time.Second,
+	}
+	addresses := makeAddresses(c.Hosts, 443)
+	result := makeCluster(c, []byte("fake-ca"), UpstreamHealthCheck{}, -1, addresses)
+
+	httpOptionsPb := result.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]
+	httpOptions := &envoy_extension_http.HttpProtocolOptions{}
+	if err := httpOptionsPb.UnmarshalTo(httpOptions); err != nil {
+		t.Fatalf("Failed to unmarshal HttpProtocolOptions: %s", err)
+	}
+
+	if httpOptions.UpstreamHttpProtocolOptions == nil {
+		t.Fatal("Expected UpstreamHttpProtocolOptions to be set")
+	}
+	if !httpOptions.UpstreamHttpProtocolOptions.AutoSni {
+		t.Error("Expected AutoSni to be true")
+	}
+	if !httpOptions.UpstreamHttpProtocolOptions.AutoSanValidation {
+		t.Error("Expected AutoSanValidation to be true")
 	}
 }
 

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -124,7 +124,7 @@ func readCABytes(path string) ([]byte, error) {
 	}
 
 	if len(combined) == 0 {
-		logrus.Warnf("no .pem or .crt files found in CA directory %q", path)
+		return nil, fmt.Errorf("no .pem or .crt files found in CA directory %q", path)
 	}
 
 	return combined, nil

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -2,7 +2,9 @@ package envoy
 
 import (
 	"errors"
+	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -65,7 +67,7 @@ type KubernetesConfigurator struct {
 	syncSecrets                bool
 	accessLog                  string
 	certificates               []Certificate
-	trustCA                    string
+	trustCABytes               []byte
 	upstreamPort               uint32
 	envoyListenPort            uint32
 	envoyListenerIpv4Address   []string
@@ -87,12 +89,62 @@ type KubernetesConfigurator struct {
 	sync.Mutex
 }
 
+// readCABytes reads CA certificate content from a file or directory path.
+// If path is a file, it reads the file directly.
+// If path is a directory, it concatenates all .pem and .crt files found in it.
+func readCABytes(path string) ([]byte, error) {
+	// Try reading as a file first.
+	data, err := os.ReadFile(path)
+	if err == nil {
+		return data, nil
+	}
+
+	// If ReadFile failed, try as a directory.
+	entries, dirErr := os.ReadDir(path)
+	if dirErr != nil {
+		return nil, fmt.Errorf("failed to read CA path %q: %w", path, err)
+	}
+
+	var combined []byte
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if ext != ".pem" && ext != ".crt" {
+			continue
+		}
+		fullPath := filepath.Join(path, name)
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA file %q: %w", fullPath, err)
+		}
+		combined = append(combined, data...)
+	}
+
+	if len(combined) == 0 {
+		logrus.Warnf("no .pem or .crt files found in CA directory %q", path)
+	}
+
+	return combined, nil
+}
+
 // NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
 func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, accessLog string, options ...option) *KubernetesConfigurator {
-	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, trustCA: ca, accessLog: accessLog}
+	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, accessLog: accessLog}
 	for _, opt := range options {
 		opt(c)
 	}
+
+	if ca != "" {
+		caBytes, err := readCABytes(ca)
+		if err != nil {
+			logrus.Fatalf("failed to read CA certificates: %v", err)
+		}
+		c.trustCABytes = caBytes
+	}
+
 	return c
 }
 
@@ -327,7 +379,7 @@ func (c *KubernetesConfigurator) generateClusters(config *envoyConfiguration) []
 
 	for _, cluster := range config.Clusters {
 		addresses := makeAddresses(cluster.Hosts, c.upstreamPort)
-		cluster := makeCluster(*cluster, c.trustCA, c.upstreamHealthCheck, c.outlierPercentage, addresses)
+		cluster := makeCluster(*cluster, c.trustCABytes, c.upstreamHealthCheck, c.outlierPercentage, addresses)
 		clusters = append(clusters, cluster)
 	}
 

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -140,7 +140,7 @@ func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca str
 	if ca != "" {
 		caBytes, err := readCABytes(ca)
 		if err != nil {
-		 	return nil, fmt.Errorf("failed to read CA certificates: %w", err)
+			return nil, fmt.Errorf("failed to read CA certificates: %w", err)
 		}
 		c.trustCABytes = caBytes
 	}

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -131,7 +131,7 @@ func readCABytes(path string) ([]byte, error) {
 }
 
 // NewKubernetesConfigurator returns a Kubernetes configurator given a lister and ingress class
-func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, accessLog string, options ...option) *KubernetesConfigurator {
+func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca string, ingressClasses []string, accessLog string, options ...option) (*KubernetesConfigurator, error) {
 	c := &KubernetesConfigurator{ingressClasses: ingressClasses, nodeID: nodeID, certificates: certificates, accessLog: accessLog}
 	for _, opt := range options {
 		opt(c)
@@ -140,12 +140,12 @@ func NewKubernetesConfigurator(nodeID string, certificates []Certificate, ca str
 	if ca != "" {
 		caBytes, err := readCABytes(ca)
 		if err != nil {
-			logrus.Fatalf("failed to read CA certificates: %v", err)
+		 	return nil, fmt.Errorf("failed to read CA certificates: %w", err)
 		}
 		c.trustCABytes = caBytes
 	}
 
-	return c
+	return c, nil
 }
 
 func (c *KubernetesConfigurator) ValidateAndFormatPath() {

--- a/pkg/envoy/configurator.go
+++ b/pkg/envoy/configurator.go
@@ -102,7 +102,7 @@ func readCABytes(path string) ([]byte, error) {
 	// If ReadFile failed, try as a directory.
 	entries, dirErr := os.ReadDir(path)
 	if dirErr != nil {
-		return nil, fmt.Errorf("failed to read CA path %q: %w", path, err)
+		return nil, fmt.Errorf("failed to read CA path %q: file error: %v, directory error: %w", path, err, dirErr)
 	}
 
 	var combined []byte

--- a/pkg/envoy/configurator_test.go
+++ b/pkg/envoy/configurator_test.go
@@ -65,9 +65,12 @@ func TestGenerate(t *testing.T) {
 		newGenericIngress("wibble", "bibble"),
 	}
 
-	configurator := NewKubernetesConfigurator("a", []Certificate{
+	configurator, err := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*"}, Cert: "b", Key: "c"},
 	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	snapshot, _ := configurator.Generate(ingresses, []*v1.Secret{})
 
@@ -86,10 +89,13 @@ func TestGenerateMultipleCerts(t *testing.T) {
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
 	}
 
-	configurator := NewKubernetesConfigurator("a", []Certificate{
+	configurator, err := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*.internal.api.co.uk"}, Cert: "couk", Key: "couk"},
 	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -113,9 +119,12 @@ func TestGenerateMultipleHosts(t *testing.T) {
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
 	}
 
-	configurator := NewKubernetesConfigurator("a", []Certificate{
+	configurator, err := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com", "*.internal.api.co.uk"}, Cert: "com", Key: "com"},
 	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -139,9 +148,12 @@ func TestGenerateNoMatchingCert(t *testing.T) {
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
 	}
 
-	configurator := NewKubernetesConfigurator("a", []Certificate{
+	configurator, err := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -161,10 +173,13 @@ func TestGenerateIntoTwoCerts(t *testing.T) {
 		newGenericIngress("foo.internal.api.com", "bibble"),
 	}
 
-	configurator := NewKubernetesConfigurator("a", []Certificate{
+	configurator, err := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*"}, Cert: "all", Key: "all"},
 	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -237,7 +252,10 @@ func TestGenerateListeners(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			configurator := NewKubernetesConfigurator("a", tc.certs, "", nil, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+			configurator, err := NewKubernetesConfigurator("a", tc.certs, "", nil, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+			if err != nil {
+				t.Fatal(err)
+			}
 			ret, err := configurator.generateListeners(&envoyConfiguration{VirtualHosts: tc.virtualHost})
 			if err != nil {
 				t.Fatalf("Error generating listeners %v", err)

--- a/pkg/envoy/configurator_test.go
+++ b/pkg/envoy/configurator_test.go
@@ -2,6 +2,8 @@ package envoy
 
 import (
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -269,6 +271,76 @@ func TestGenerateListeners(t *testing.T) {
 				if listener.FilterChains[0].FilterChainMatch == nil {
 					t.Fatalf("Expected filter chain")
 				}
+			}
+		})
+	}
+}
+
+func TestReadCABytes(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string
+		wantErr   string
+		checkData func(t *testing.T, data []byte)
+	}{
+		{
+			name: "directory with pem and crt files",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				os.WriteFile(filepath.Join(dir, "ca1.pem"), []byte("PEM1"), 0644)
+				os.WriteFile(filepath.Join(dir, "ca2.crt"), []byte("CRT2"), 0644)
+				os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("skip me"), 0644)
+				os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
+				return dir
+			},
+			checkData: func(t *testing.T, data []byte) {
+				s := string(data)
+				if !strings.Contains(s, "PEM1") || !strings.Contains(s, "CRT2") {
+					t.Errorf("expected concatenated cert contents, got %q", s)
+				}
+				if strings.Contains(s, "skip me") {
+					t.Error("non-cert file content should not be included")
+				}
+			},
+		},
+		{
+			name: "invalid path",
+			setup: func(t *testing.T) string {
+				return "/nonexistent/path/to/ca"
+			},
+			wantErr: "failed to read CA path",
+		},
+		{
+			name: "empty directory",
+			setup: func(t *testing.T) string {
+				dir := t.TempDir()
+				os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not a cert"), 0644)
+				return dir
+			},
+			wantErr: "no .pem or .crt files found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+			data, err := readCABytes(path)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.checkData != nil {
+				tt.checkData(t, data)
 			}
 		})
 	}

--- a/pkg/envoy/configurator_test.go
+++ b/pkg/envoy/configurator_test.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -10,6 +11,19 @@ import (
 	"github.com/uswitch/yggdrasil/pkg/k8s"
 	v1 "k8s.io/api/core/v1"
 )
+
+func createTempCAFile(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "ca-*.pem")
+	if err != nil {
+		t.Fatalf("failed to create temp CA file: %v", err)
+	}
+	if _, err := f.WriteString("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"); err != nil {
+		t.Fatalf("failed to write temp CA file: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
 
 func assertNumberOfVirtualHosts(t *testing.T, filterChain *listener.FilterChain, expected int) {
 	filter, err := filterChain.Filters[0].GetTypedConfig().UnmarshalNew()
@@ -46,13 +60,14 @@ func assertServerNames(t *testing.T, filterChain *listener.FilterChain, expected
 }
 
 func TestGenerate(t *testing.T) {
+	caFile := createTempCAFile(t)
 	ingresses := []*k8s.Ingress{
 		newGenericIngress("wibble", "bibble"),
 	}
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*"}, Cert: "b", Key: "c"},
-	}, "d", []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
 
 	snapshot, _ := configurator.Generate(ingresses, []*v1.Secret{})
 
@@ -65,6 +80,7 @@ func TestGenerate(t *testing.T) {
 }
 
 func TestGenerateMultipleCerts(t *testing.T) {
+	caFile := createTempCAFile(t)
 	ingresses := []*k8s.Ingress{
 		newGenericIngress("foo.internal.api.com", "bibble"),
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
@@ -73,7 +89,7 @@ func TestGenerateMultipleCerts(t *testing.T) {
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*.internal.api.co.uk"}, Cert: "couk", Key: "couk"},
-	}, "d", []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -91,6 +107,7 @@ func TestGenerateMultipleCerts(t *testing.T) {
 }
 
 func TestGenerateMultipleHosts(t *testing.T) {
+	caFile := createTempCAFile(t)
 	ingresses := []*k8s.Ingress{
 		newGenericIngress("foo.internal.api.com", "bibble"),
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
@@ -98,7 +115,7 @@ func TestGenerateMultipleHosts(t *testing.T) {
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com", "*.internal.api.co.uk"}, Cert: "com", Key: "com"},
-	}, "d", []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -116,6 +133,7 @@ func TestGenerateMultipleHosts(t *testing.T) {
 }
 
 func TestGenerateNoMatchingCert(t *testing.T) {
+	caFile := createTempCAFile(t)
 	ingresses := []*k8s.Ingress{
 		newGenericIngress("foo.internal.api.com", "bibble"),
 		newGenericIngress("foo.internal.api.co.uk", "bibble"),
@@ -123,7 +141,7 @@ func TestGenerateNoMatchingCert(t *testing.T) {
 
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
-	}, "d", []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {
@@ -138,6 +156,7 @@ func TestGenerateNoMatchingCert(t *testing.T) {
 }
 
 func TestGenerateIntoTwoCerts(t *testing.T) {
+	caFile := createTempCAFile(t)
 	ingresses := []*k8s.Ingress{
 		newGenericIngress("foo.internal.api.com", "bibble"),
 	}
@@ -145,7 +164,7 @@ func TestGenerateIntoTwoCerts(t *testing.T) {
 	configurator := NewKubernetesConfigurator("a", []Certificate{
 		{Hosts: []string{"*.internal.api.com"}, Cert: "com", Key: "com"},
 		{Hosts: []string{"*"}, Cert: "all", Key: "all"},
-	}, "d", []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
+	}, caFile, []string{"bar"}, "/var/log/envoy/", func(c *KubernetesConfigurator) { c.envoyListenerIpv4Address = []string{"1.1.1.1"} })
 
 	snapshot, err := configurator.Generate(ingresses, []*v1.Secret{})
 	if err != nil {


### PR DESCRIPTION
Due to a change in this PR : https://github.com/envoyproxy/envoy/pull/39751. Validation of cert was broken, this pr ensures that envoy proxy 1.37.1.