### PR TITLE
feat: implement gateway upstream resolution precedence

### DIFF
--- a/docs/GETTINGSTARTED.md
+++ b/docs/GETTINGSTARTED.md
@@ -122,6 +122,24 @@ If `syncSecrets` is enabled, add read access to TLS secrets as well:
   verbs: ["get", "list", "watch"]
 ```
 
+### Gateway address discovery
+
+For each Gateway, Yggdrasil discovers the data-plane address used as Envoy
+upstream endpoints in the following order (first match wins):
+
+1. `Gateway.status.addresses` (published by any conformant Gateway API
+   implementation), combined with the listener port.
+2. A Service in the Gateway's namespace whose `ownerReferences` point at the
+   Gateway (per-Gateway deployments), using its `externalIPs` or LoadBalancer
+   ingress.
+3. The optional `serviceNamespace`/`serviceName` fields of the matching
+   `gatewayClasses` entry in the Yggdrasil configuration. This is only needed
+   for implementations that share one Service across Gateways without
+   publishing status addresses (e.g. Envoy Gateway merged mode with
+   `externalIPs`, see envoyproxy/gateway#8987).
+
+If no address is found, the route is skipped and a diagnostic is reported.
+
 For Gateway API HTTPS listeners, Yggdrasil currently uses only the first
 `listener.tls.certificateRefs` entry. Additional certificate references are
 ignored and reported as diagnostics.

--- a/pkg/k8s/gateway_resources.go
+++ b/pkg/k8s/gateway_resources.go
@@ -98,18 +98,25 @@ func ConvertGatewayResources(stores GatewayStores) (GatewayConversionResult, err
 					if len(hosts) == 0 {
 						continue
 					}
-					upstreams := gatewayServiceUpstreams(classConfig, listener, serviceByKey)
+					source := RouteSource{
+						Kind:                  "HTTPRoute",
+						Namespace:             route.Namespace,
+						Name:                  route.Name,
+						Class:                 classConfig.Name,
+						KubernetesClusterName: stores.ClusterName,
+					}
+					upstreams := resolveGatewayUpstreams(gateway, listener, classConfig, serviceByKey)
 					if len(upstreams) == 0 {
+						for _, host := range hosts {
+							result.Diagnostics = append(result.Diagnostics, GatewayDiagnostic{
+								Host:   host,
+								Source: source,
+								Reason: fmt.Sprintf("no gateway address found for gateway %s/%s: empty status.addresses, no owned Service, no serviceName configured for class %s", gateway.Namespace, gateway.Name, classConfig.Name),
+							})
+						}
 						continue
 					}
 					if denyReason := listenerSecretRefDenyReason(gateway, listener, stores.ReferenceGrants); denyReason != "" {
-						source := RouteSource{
-							Kind:                  "HTTPRoute",
-							Namespace:             route.Namespace,
-							Name:                  route.Name,
-							Class:                 classConfig.Name,
-							KubernetesClusterName: stores.ClusterName,
-						}
 						for _, host := range hosts {
 							result.Diagnostics = append(result.Diagnostics, GatewayDiagnostic{
 								Host:   host,
@@ -118,13 +125,6 @@ func ConvertGatewayResources(stores GatewayStores) (GatewayConversionResult, err
 							})
 						}
 						continue
-					}
-					source := RouteSource{
-						Kind:                  "HTTPRoute",
-						Namespace:             route.Namespace,
-						Name:                  route.Name,
-						Class:                 classConfig.Name,
-						KubernetesClusterName: stores.ClusterName,
 					}
 					for _, diagnostic := range listenerCertificateRefDiagnostics(source, listener, hosts) {
 						result.Diagnostics = append(result.Diagnostics, diagnostic)
@@ -240,11 +240,67 @@ func hostMatchesGatewayListener(routeHost, listenerHost string) bool {
 	return false
 }
 
+// resolveGatewayUpstreams discovers the Gateway Address (data-plane endpoints) for a
+// listener, in vendor-agnostic precedence order (see docs/adr/0002):
+//  1. Gateway.status.addresses (spec-guaranteed) with the listener port
+//  2. a Service owned by the Gateway (per-Gateway deployments)
+//  3. the static serviceName/serviceNamespace from config.json (escape hatch for
+//     merged/shared deployments whose implementation does not publish status addresses)
+func resolveGatewayUpstreams(gateway *gatewayv1.Gateway, listener gatewayv1.Listener, classConfig GatewayClassConfig, services map[string]*v1.Service) []UpstreamEndpoint {
+	if upstreams := gatewayStatusUpstreams(gateway, listener); len(upstreams) > 0 {
+		return upstreams
+	}
+	if upstreams := ownedServiceUpstreams(gateway, listener, services); len(upstreams) > 0 {
+		return upstreams
+	}
+	return gatewayServiceUpstreams(classConfig, listener, services)
+}
+
+func gatewayStatusUpstreams(gateway *gatewayv1.Gateway, listener gatewayv1.Listener) []UpstreamEndpoint {
+	upstreams := []UpstreamEndpoint{}
+	for _, address := range gateway.Status.Addresses {
+		if address.Value == "" {
+			continue
+		}
+		upstreams = append(upstreams, UpstreamEndpoint{Host: address.Value, Port: uint32(listener.Port)})
+	}
+	return uniqueUpstreams(upstreams)
+}
+
+func ownedServiceUpstreams(gateway *gatewayv1.Gateway, listener gatewayv1.Listener, services map[string]*v1.Service) []UpstreamEndpoint {
+	owned := []*v1.Service{}
+	for _, service := range services {
+		if service.Namespace == gateway.Namespace && isOwnedByGateway(service, gateway) {
+			owned = append(owned, service)
+		}
+	}
+	sort.Slice(owned, func(i, j int) bool { return owned[i].Name < owned[j].Name })
+	for _, service := range owned {
+		if upstreams := serviceUpstreams(service, listener); len(upstreams) > 0 {
+			return upstreams
+		}
+	}
+	return nil
+}
+
+func isOwnedByGateway(service *v1.Service, gateway *gatewayv1.Gateway) bool {
+	for _, owner := range service.OwnerReferences {
+		if owner.Kind == "Gateway" && owner.Name == gateway.Name && strings.HasPrefix(owner.APIVersion, "gateway.networking.k8s.io/") {
+			return true
+		}
+	}
+	return false
+}
+
 func gatewayServiceUpstreams(classConfig GatewayClassConfig, listener gatewayv1.Listener, services map[string]*v1.Service) []UpstreamEndpoint {
 	service := services[namespacedName(classConfig.ServiceNamespace, classConfig.ServiceName)]
 	if service == nil {
 		return nil
 	}
+	return serviceUpstreams(service, listener)
+}
+
+func serviceUpstreams(service *v1.Service, listener gatewayv1.Listener) []UpstreamEndpoint {
 	port := servicePortForListener(service, listener)
 	if port == 0 {
 		return nil

--- a/pkg/k8s/gateway_resources_test.go
+++ b/pkg/k8s/gateway_resources_test.go
@@ -641,3 +641,79 @@ func namespacePtr(namespace string) *gatewayv1.Namespace {
 func fromNamespacesPtr(from gatewayv1.FromNamespaces) *gatewayv1.FromNamespaces {
 	return &from
 }
+
+func TestResolveGatewayUpstreamsPrecedence(t *testing.T) {
+	listener := gatewayv1.Listener{Name: gatewayv1.SectionName("https"), Port: gatewayv1.PortNumber(443), Protocol: gatewayv1.HTTPSProtocolType}
+	classConfig := GatewayClassConfig{Name: "public", ServiceNamespace: "gateway-system", ServiceName: "envoy"}
+	configuredService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "envoy", Namespace: "gateway-system"},
+		Spec:       corev1.ServiceSpec{ExternalIPs: []string{"10.0.0.3"}, Ports: []corev1.ServicePort{{Port: 443}}},
+	}
+	ownedService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "edge-owned",
+			Namespace:       "gateway-system",
+			OwnerReferences: []metav1.OwnerReference{{APIVersion: "gateway.networking.k8s.io/v1", Kind: "Gateway", Name: "edge"}},
+		},
+		Spec: corev1.ServiceSpec{ExternalIPs: []string{"10.0.0.2"}, Ports: []corev1.ServicePort{{Port: 443}}},
+	}
+	gatewayWithStatus := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", Namespace: "gateway-system"},
+		Status: gatewayv1.GatewayStatus{
+			Addresses: []gatewayv1.GatewayStatusAddress{{Value: "10.0.0.1"}, {Value: "lb.example.net"}},
+		},
+	}
+	gatewayWithoutStatus := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "edge", Namespace: "gateway-system"}}
+
+	services := map[string]*corev1.Service{
+		"gateway-system/envoy":      configuredService,
+		"gateway-system/edge-owned": ownedService,
+	}
+
+	got := resolveGatewayUpstreams(gatewayWithStatus, listener, classConfig, services)
+	want := []UpstreamEndpoint{{Host: "10.0.0.1", Port: 443}, {Host: "lb.example.net", Port: 443}}
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("expected status addresses to win, got %+v", got)
+	}
+
+	got = resolveGatewayUpstreams(gatewayWithoutStatus, listener, classConfig, services)
+	if len(got) != 1 || got[0] != (UpstreamEndpoint{Host: "10.0.0.2", Port: 443}) {
+		t.Fatalf("expected owned Service fallback, got %+v", got)
+	}
+
+	got = resolveGatewayUpstreams(gatewayWithoutStatus, listener, classConfig, map[string]*corev1.Service{"gateway-system/envoy": configuredService})
+	if len(got) != 1 || got[0] != (UpstreamEndpoint{Host: "10.0.0.3", Port: 443}) {
+		t.Fatalf("expected configured Service fallback, got %+v", got)
+	}
+
+	got = resolveGatewayUpstreams(gatewayWithoutStatus, listener, GatewayClassConfig{Name: "public"}, map[string]*corev1.Service{})
+	if len(got) != 0 {
+		t.Fatalf("expected no upstreams without any discovery source, got %+v", got)
+	}
+}
+
+func TestOwnedServiceUpstreamsIgnoresForeignOwners(t *testing.T) {
+	listener := gatewayv1.Listener{Port: gatewayv1.PortNumber(443)}
+	gateway := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "edge", Namespace: "gateway-system"}}
+	services := map[string]*corev1.Service{
+		"gateway-system/other": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "other",
+				Namespace:       "gateway-system",
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "apps/v1", Kind: "Deployment", Name: "edge"}},
+			},
+			Spec: corev1.ServiceSpec{ExternalIPs: []string{"10.0.0.9"}, Ports: []corev1.ServicePort{{Port: 443}}},
+		},
+		"apps/edge-owned": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "edge-owned",
+				Namespace:       "apps",
+				OwnerReferences: []metav1.OwnerReference{{APIVersion: "gateway.networking.k8s.io/v1", Kind: "Gateway", Name: "edge"}},
+			},
+			Spec: corev1.ServiceSpec{ExternalIPs: []string{"10.0.0.8"}, Ports: []corev1.ServicePort{{Port: 443}}},
+		},
+	}
+	if got := ownedServiceUpstreams(gateway, listener, services); len(got) != 0 {
+		t.Fatalf("expected no owned upstreams (wrong owner kind / wrong namespace), got %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

  Implements deterministic Gateway upstream address discovery for HTTPRoute-derived routes.

  Yggdrasil now resolves Gateway data-plane upstreams in this order:

  1. `Gateway.status.addresses`, using the listener port.
  2. A Service in the Gateway namespace owned by that Gateway.
  3. The configured `gatewayClasses[].serviceNamespace/serviceName` fallback.

  If no address can be resolved, the route is skipped and a diagnostic is emitted instead of silently producing an unusable upstream.

  ## Details

  - Add `resolveGatewayUpstreams` with vendor-neutral precedence.
  - Support Gateway-owned Service discovery for per-Gateway deployments.
  - Keep the configured Service fallback for shared/merged Gateway deployments.
  - Add diagnostics when a Gateway has no resolvable address.
  - Document Gateway address discovery behavior in `GETTINGSTARTED.md`.