### PR TITLE
fix: skip gateway informers when Gateway API CRDs absent

### DIFF
--- a/pkg/k8s/aggregator.go
+++ b/pkg/k8s/aggregator.go
@@ -80,8 +80,9 @@ func NewAggregator(k8sClients []KubernetesConfig, ctx context.Context, syncSecre
 		informersSynced = append(informersSynced, ingressInformer.HasSynced)
 
 		if len(c.gatewayClasses) > 0 {
-			gatewayClient, err := gatewayclient.NewForConfig(c.restConfig)
-			if err != nil {
+			if _, err := c.source.ServerResourcesForGroupVersion("gateway.networking.k8s.io/v1"); err != nil {
+				logrus.Warnf("Gateway API not available in cluster %s, skipping gateway informers: %v", c.kubernetesClusterName, err)
+			} else if gatewayClient, err := gatewayclient.NewForConfig(c.restConfig); err != nil {
 				logrus.Warnf("Gateway API client unavailable for cluster %s: %v", c.kubernetesClusterName, err)
 			} else {
 				gatewayFactory := gatewayinformers.NewSharedInformerFactory(gatewayClient, time.Minute)


### PR DESCRIPTION
## Bug

When `gatewayClasses` is configured but the `gateway.networking.k8s.io` CRDs are not installed on a cluster, the Gateway API informers (GatewayClasses, Gateways, HTTPRoutes, ReferenceGrants, plus Services/Namespaces) were wired unconditionally. The only guard was `gatewayclient.NewForConfig`, which never contacts the API server. Their `HasSynced` never becomes true, so `cache.WaitForCacheSync` at startup blocks forever — hanging the whole process, including unrelated Ingress-only clusters sharing it.

## Fix

Add a discovery guard on `gateway.networking.k8s.io/v1` (via `c.source.ServerResourcesForGroupVersion`) before wiring the Gateway block, warning and skipping if unavailable. This mirrors the existing degrade-gracefully pattern already used for the YggdrasilPolicy CRD and Ingress API groups in the same file.