### PR TITLE
fix: TLS precedence on shared hosts + upstream SNI regression

### DIFF
--- a/pkg/envoy/boilerplate.go
+++ b/pkg/envoy/boilerplate.go
@@ -517,7 +517,7 @@ func makeHealthChecks(upstreamVHost string, healthPath string, config UpstreamHe
 
 func makeCluster(c cluster, ca string, healthCfg UpstreamHealthCheck, outlierPercentage int32, addresses []*core.Address) *v3cluster.Cluster {
 
-	tls := &auth.UpstreamTlsContext{Sni: c.VirtualHost}
+	tls := &auth.UpstreamTlsContext{}
 	if ca != "" {
 		tls.CommonTlsContext = &auth.CommonTlsContext{
 			ValidationContextType: &auth.CommonTlsContext_ValidationContext{

--- a/pkg/envoy/boilerplate_test.go
+++ b/pkg/envoy/boilerplate_test.go
@@ -10,9 +10,29 @@ import (
 	eal "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	stateful_session "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/stateful_session/v3"
 	cookie_session "github.com/envoyproxy/go-control-plane/envoy/extensions/http/stateful_session/cookie/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_extension_http "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes/duration"
 )
+
+func TestMakeClusterUpstreamTLSHasNoSNI(t *testing.T) {
+	c := cluster{VirtualHost: "test.example.com", Hosts: []LBHost{{Host: "host1", Weight: 1}}}
+	addresses := []*core.Address{
+		{Address: &core.Address_SocketAddress{SocketAddress: &core.SocketAddress{Address: "host1", PortSpecifier: &core.SocketAddress_PortValue{PortValue: 443}}}},
+	}
+	result := makeCluster(c, "/etc/ssl/ca.pem", UpstreamHealthCheck{}, -1, addresses)
+
+	if result.TransportSocket == nil {
+		t.Fatal("expected TransportSocket to be set")
+	}
+	var tlsCtx auth.UpstreamTlsContext
+	if err := result.TransportSocket.GetTypedConfig().UnmarshalTo(&tlsCtx); err != nil {
+		t.Fatalf("failed to unmarshal UpstreamTlsContext: %s", err)
+	}
+	if tlsCtx.Sni != "" {
+		t.Errorf("expected empty SNI, got %q", tlsCtx.Sni)
+	}
+}
 
 func TestMakeHealthChecksEmptyPath(t *testing.T) {
 	healthChecks := makeHealthChecks("example.com", "", UpstreamHealthCheck{})

--- a/pkg/envoy/ingress_translator.go
+++ b/pkg/envoy/ingress_translator.go
@@ -556,7 +556,7 @@ func translateIngresses(ingresses []*k8s.SourceRoute, syncSecrets bool, secrets 
 
 			applyRoutePolicy(envoyIngress, ingress.Policy, ruleHost, isWildcard)
 
-			if syncSecrets && envoyIngress.vhost.TlsKey == "" && envoyIngress.vhost.TlsCert == "" {
+			if syncSecrets {
 				if hostTlsSecret, err := getHostTlsSecret(ingress, ruleHost, secrets); err != nil {
 					logrus.Infof("%s", err.Error())
 				} else {

--- a/pkg/envoy/ingress_translator_test.go
+++ b/pkg/envoy/ingress_translator_test.go
@@ -825,6 +825,62 @@ func TestTranslateIngressesAppliesHTTPRoutePolicyAfterIngress(t *testing.T) {
 	}
 }
 
+func TestTranslateIngressesHTTPRouteCertOverridesIngressCert(t *testing.T) {
+	timeouts := DefaultTimeouts{Cluster: 30 * time.Second, Route: 15 * time.Second, PerTry: 5 * time.Second}
+
+	ingress := newGenericIngress("app.com", "ingress-upstream.com")
+	ingress.Namespace = "ns1"
+	ingress.TLS = map[string]*k8s.IngressTLS{"app.com": {Host: "app.com", SecretName: "rsa-secret"}}
+
+	httpRoute := newGenericIngress("app.com", "httproute-upstream.com")
+	httpRoute.Namespace = "ns1"
+	httpRoute.Source = k8s.RouteSource{Kind: "HTTPRoute"}
+	httpRoute.TLS = map[string]*k8s.IngressTLS{"app.com": {Host: "app.com", SecretName: "p256-secret"}}
+
+	secrets := []*v1.Secret{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "rsa-secret"}, Data: map[string][]byte{"tls.crt": []byte(rsa2048crt), "tls.key": []byte(rsa2048key)}},
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "p256-secret"}, Data: map[string][]byte{"tls.crt": []byte(p256crt), "tls.key": []byte(p256key)}},
+	}
+
+	cfg := translateIngresses([]*k8s.SourceRoute{httpRoute, ingress}, true, secrets, timeouts, "/var/log/envoy/")
+	if len(cfg.VirtualHosts) != 1 {
+		t.Fatalf("expected 1 virtual host, got %d", len(cfg.VirtualHosts))
+	}
+	if cfg.VirtualHosts[0].TlsCert != p256crt {
+		t.Errorf("expected HTTPRoute (p256) cert to win, got %q", cfg.VirtualHosts[0].TlsCert)
+	}
+	if cfg.VirtualHosts[0].TlsKey != p256key {
+		t.Errorf("expected HTTPRoute (p256) key to win, got %q", cfg.VirtualHosts[0].TlsKey)
+	}
+}
+
+func TestTranslateIngressesHTTPRouteWithoutTLSKeepsIngressCert(t *testing.T) {
+	timeouts := DefaultTimeouts{Cluster: 30 * time.Second, Route: 15 * time.Second, PerTry: 5 * time.Second}
+
+	ingress := newGenericIngress("app.com", "ingress-upstream.com")
+	ingress.Namespace = "ns1"
+	ingress.TLS = map[string]*k8s.IngressTLS{"app.com": {Host: "app.com", SecretName: "rsa-secret"}}
+
+	httpRoute := newGenericIngress("app.com", "httproute-upstream.com")
+	httpRoute.Namespace = "ns1"
+	httpRoute.Source = k8s.RouteSource{Kind: "HTTPRoute"}
+
+	secrets := []*v1.Secret{
+		{ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "rsa-secret"}, Data: map[string][]byte{"tls.crt": []byte(rsa2048crt), "tls.key": []byte(rsa2048key)}},
+	}
+
+	cfg := translateIngresses([]*k8s.SourceRoute{httpRoute, ingress}, true, secrets, timeouts, "/var/log/envoy/")
+	if len(cfg.VirtualHosts) != 1 {
+		t.Fatalf("expected 1 virtual host, got %d", len(cfg.VirtualHosts))
+	}
+	if cfg.VirtualHosts[0].TlsCert != rsa2048crt {
+		t.Errorf("expected Ingress (rsa) cert to be kept, got %q", cfg.VirtualHosts[0].TlsCert)
+	}
+	if cfg.VirtualHosts[0].TlsKey != rsa2048key {
+		t.Errorf("expected Ingress (rsa) key to be kept, got %q", cfg.VirtualHosts[0].TlsKey)
+	}
+}
+
 func TestStickySessionAnnotationParsing(t *testing.T) {
 	ingress := newGenericIngressWithAnnotations("app.com", "foo.com", map[string]string{
 		"yggdrasil.uswitch.com/sticky-sessions":            "true",


### PR DESCRIPTION
## Fix 1 — upstream SNI regression

`makeCluster` set the upstream TLS context SNI to `c.VirtualHost`, which regressed upstream TLS behavior. The one-line change drops the SNI: `tls := &auth.UpstreamTlsContext{}` (no `Sni` field). `c.VirtualHost` is still used elsewhere legitimately.

## Fix 2 — TLS precedence on shared hosts (first-write-wins → last-write-wins)

In the `translateIngresses` merge loop, the TLS secret resolution was guarded by `TlsKey == "" && TlsCert == ""`, so the first source to set a cert on a shared host won permanently. Changed the guard to just `if syncSecrets`. The inner block still only writes when the secret is valid, so a later valid cert overrides an earlier one while errors/missing secrets preserve the earlier cert.

Behavior call-outs:
- HTTPRoute is sorted last, so on a shared host an HTTPRoute cert now wins over an Ingress cert ("HTTPRoute wins"). Maintenance-drain still suspends this (the source is skipped).
- Two same-priority Ingresses on a shared host now last-write-wins on TLS too.
