### PR TITLE
docs: add OpenWiki documentation wiki

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,16 @@
 # Agent instructions
 
+## OpenWiki
+
+This repository has documentation located in the /openwiki directory.
+
+Start here:
+- [OpenWiki quickstart](openwiki/quickstart.md)
+
+OpenWiki includes repository overview, architecture notes, workflows, domain concepts, operations, integrations, testing guidance, and source maps.
+
+When working in this repository, read the OpenWiki quickstart first, then follow its links to the relevant architecture, workflow, domain, operation, and testing notes.
+
 ## Project overview
 
 - Yggdrasil is a Go-based Envoy control plane.

--- a/openwiki/.last-update.json
+++ b/openwiki/.last-update.json
@@ -1,0 +1,6 @@
+{
+  "updatedAt": "2026-07-06T08:47:56.000Z",
+  "command": "init",
+  "gitHead": "7362f9eb45772729162e28d8814e809a970ce17e",
+  "model": "claude-opus-4-8"
+}

--- a/openwiki/architecture.md
+++ b/openwiki/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+Yggdrasil is a pipeline with one direction of flow, stated in `AGENTS.md`:
+
+> Kubernetes input → normalized internal model → Envoy output.
+
+Everything below is an elaboration of that sentence. When changing behavior, follow
+the data along this path and prefer fixing the shared model layer over a single caller.
+
+## The three stages
+
+### 1. Aggregator — watch & coalesce (`pkg/k8s/aggregator.go`)
+
+`NewAggregator` (`aggregator.go:56`) builds, **per cluster**, a set of shared informers
+(Ingress, optionally Gateway API + `YggdrasilPolicy`, optionally Secrets) and blocks on
+`cache.WaitForCacheSync` before returning. Details of informer selection and Gateway API
+opt-in live in [kubernetes-integration](kubernetes-integration.md).
+
+Informer callbacks do **not** carry payloads — they only push a typed signal onto a
+buffered channel (`pkg/k8s/handlers.go`):
+
+- `EventsIngresses` → `SyncType: INGRESS` (Ingress **and** all Gateway/Policy informers)
+- `EventsSecrets` → `SyncType: SECRET`
+- `Aggregator.Run` (`aggregator.go:181`) ticks a `COMMAND` event every 5 s.
+
+Only three `SyncType` values exist (`pkg/k8s/types.go:34`): `COMMAND`, `INGRESS`,
+`SECRET`. Gateway API and CRD changes are deliberately folded under `INGRESS`.
+
+### 2. Snapshotter — debounce & trigger (`pkg/envoy/snapshotter.go`)
+
+`Snapshotter.Run` (`snapshotter.go:57`) reads the event channel:
+
+- `INGRESS` / `SECRET` set an internal `hadChanges` flag (no work done yet).
+- the periodic `COMMAND` tick is what actually calls `snapshot()` — **but only if
+  `hadChanges` is set**.
+
+This is a **coalescing/debounce** design: a storm of resource events collapses into at
+most one snapshot every 5 seconds. `snapshot()` (`snapshotter.go:33`) pulls
+`aggregator.GetSourceRoutes()` + `GetSecrets()`, calls `Configurator.Generate(...)`, and
+installs the result with `SetSnapshot`. The `Configurator` dependency is an interface
+(`snapshotter.go`), so the snapshotter is decoupled from Envoy specifics.
+
+### 3. Configurator — translate & version (`pkg/envoy/configurator.go`)
+
+`KubernetesConfigurator.Generate(ingresses, secrets)` (`configurator.go:119`) is the
+heart of xDS generation and is **mutex-guarded** (it holds `previousConfig` and version
+counters). It:
+
+1. Filters `SourceRoute`s by ingress class (`classFilter`) and validity
+   (`validIngressFilter`) — HTTPRoutes bypass class filtering.
+2. Calls `translateIngresses` (`pkg/envoy/ingress_translator.go:462`) to build the
+   intermediate `envoyConfiguration` (virtual hosts + clusters).
+3. **Diffs against `previousConfig`** and bumps `listenerVersion` / `clusterVersion`
+   (each a `time.Now().String()`) **only for the resource type that changed** — so Envoy
+   re-syncs listeners and clusters independently.
+4. Packs Listeners + Clusters into a go-control-plane `cache.Snapshot` and updates
+   Prometheus counters.
+
+## What is served (and what is not)
+
+This is the single most load-bearing fact about the config model:
+
+- **Served:** Listeners (LDS) and Clusters (CDS) only.
+- **Routes are inlined** into each HTTP Connection Manager's `RouteConfig` — there is
+  **no RDS**.
+- Clusters are **`STRICT_DNS`** with inline LB endpoints — there is **no EDS**.
+
+So a "route change" surfaces as a **listener** update, not a route update. See
+[envoy-generation](envoy-generation.md) for how the protos are built.
+
+The snapshot is stored in a `SnapshotCache` keyed by **NodeID** (`--node-name`); the
+gRPC ADS/xDS server (`cmd/server.go:55`) streams it to every Envoy whose `--service-node`
+matches. Server wiring, ports, and callbacks are covered in
+[configuration](configuration.md).
+
+## Relevant tests
+
+- `pkg/envoy/configurator_test.go` — end-to-end `Generate` behavior, versioning.
+- `pkg/envoy/ingress_translator_test.go` — the model-building core (host merging,
+  precedence, maintenance, policy application).
+- `pkg/k8s/aggregator.go` has no dedicated aggregator test; informer/conversion logic is
+  covered by `pkg/k8s/generic_resources_test.go`, `gateway_resources_test.go`,
+  `gateway_policy_test.go`.
+
+Run everything with `make test`.

--- a/openwiki/configuration.md
+++ b/openwiki/configuration.md
@@ -1,0 +1,93 @@
+# Configuration & Operations
+
+## CLI, flags, and config file
+
+Startup chain: `main.go` → `cmd.Execute()` → Cobra `rootCmd` → `main`
+(`cmd/root.go:173`). Configuration uses **Cobra + Viper**: flags are defined on
+`PersistentFlags` (`cmd/root.go:82`) and each is bound with `viper.BindPFlag`
+(`cmd/root.go:122`) using dotted keys (e.g. `httpExtAuthz.timeout`) so a nested config
+file and the flags share one keyspace. `--config` (JSON **or** YAML) is read only when
+set (`initConfig`, `cmd/root.go:161`); everything is then `viper.Unmarshal`-ed into the
+`config` struct (`cmd/root.go:35`).
+
+The full flag reference with defaults lives in **`README.md`** (the canonical list) — do
+not duplicate it here. Notable groups:
+
+- **Listen addresses**: `--address` (xDS gRPC, default `0.0.0.0:8080`),
+  `--health-address` (HTTP, default `0.0.0.0:8081`).
+- **Identity**: `--node-name` — must equal each Envoy's `--service-node`.
+- **Envoy data plane**: `--envoy-listener-ipv4-address` (default `0.0.0.0`),
+  `--envoy-port` (default `10000`), `--upstream-port` (default `443`).
+- **Downstream TLS**: `--cert` / `--key` (required together), `--ca` (viper key
+  `trustCA`), `--alpn-protocols`.
+- **Watching**: `--ingress-classes`, `--kube-config` (repeatable).
+- **Defaults & tuning**: `--default-route-timeout` (15s),
+  `--default-cluster-timeout` (30s), `--default-per-try-timeout` (5s), `--retry-on`
+  (`5xx`, validated at startup), `--max-ejection-percentage` (-1 = off),
+  `--host-selection-retry-attempts` (-1 = off), the `--upstream-healthcheck-*` set,
+  `--use-remote-address`.
+- **Filters/loggers**: `--http-ext-authz-*`, `--http-grpc-logger-*`, `--tracing-provider`
+  (only zipkin supported), `--config-dump`, `--debug`.
+
+**Config-file-only** fields (no flag): `certificates[]`, `clusters[]`, `syncSecrets`,
+and `accessLogger.format` (the access-log field map — see `docs/ACCESSLOG.md`).
+
+### Certificates & TLS guards
+
+`checkDownStreamTLSSetup` (`cmd/root.go`) requires `--cert` and `--key` together. If
+`certificates` is empty but `--cert`/`--key` are set, a wildcard `{Hosts:["*"]}`
+certificate is synthesized; cert/key file contents are read and inlined into the served
+config. Guard: `syncSecrets: true` allows **only one** certificate (the fallback for
+hosts with a missing/invalid secret).
+
+### Multi-cluster `clusters[]`
+
+Each `clusterConfig` (`cmd/root.go:25`): `apiServer` + `token`/`tokenPath` + `ca`,
+optional `maintenance`, `kubernetesClusterName` (metrics label), and `gatewayClasses`
+(enables Gateway API for that cluster). See
+[kubernetes-integration](kubernetes-integration.md).
+
+## Servers & ports
+
+`runEnvoyServer` (`cmd/server.go:55`) runs two servers:
+
+- **gRPC xDS/ADS** on `--address` (8080): registers ADS, EDS, CDS, RDS, LDS services with
+  Prometheus interceptors. Envoy nodes connect here. A `callbacks` struct
+  (`cmd/server.go:24`) counts fetch requests; graceful shutdown via `GracefulStop`.
+  (Note: although all five xDS services are registered, only Listeners and Clusters carry
+  data — see [architecture](architecture.md).)
+- **Health/metrics HTTP** on `--health-address` (8081): `GET /metrics`
+  (`cmd/server.go:80`, promhttp), `GET /healthz` (always 200), and `GET /configdump`
+  (registered only with `--config-dump`; returns the current snapshot as JSON via
+  `Snapshotter.ConfigDump`).
+
+## Metrics
+
+Prometheus metrics are exposed at `/metrics` on the health address. The Yggdrasil-specific
+gauges/counters (`yggdrasil_cluster_updates`, `yggdrasil_clusters`, `yggdrasil_ingresses`,
+`yggdrasil_listener_updates`, `yggdrasil_virtual_hosts`,
+`yggdrasil_kubernetes_cluster_in_maintenance`, `yggdrasil_upstream_info`) are registered
+in `pkg/envoy/metrics.go`; the full table is in `README.md`.
+
+## Build, test, CI
+
+- **Makefile**: `make test` (`go test -v -cover`, excludes vendor), `make bench`,
+  `make build-linux` / `build-darwin` (static, `CGO_ENABLED=0`), `make docker`,
+  `make clean`. No lint target.
+- **Dockerfile**: `FROM scratch`, copies the static `bin/yggdrasil-linux-amd64` as
+  `/yggdrasil`. Minimal, statically linked image.
+- **CI** (`.github/workflows/push.yaml`, on push): `test` → `build` (uploads `bin/`
+  artifact) → `docker-build-push` (only on `master` or `v*` tags; pushes
+  `quay.io/uswitch/yggdrasil`). Go version is read from `go.mod` (**Go 1.25**).
+
+Per `AGENTS.md`: run `make test` after any change to Go code, `go.mod`/`go.sum`, or
+behavior-affecting config, and update `README.md`/`docs/` in the same change when public
+behavior (flags, annotations, CRDs, config semantics) changes.
+
+## Deployment model
+
+Yggdrasil runs as a standalone control-plane process **outside** the data plane. A fleet
+of Envoy nodes connects to its gRPC address and pulls dynamic listeners/clusters over
+ADS. Distributed as `quay.io/uswitch/yggdrasil` (scratch image). See `README.md` for the
+minimal Envoy bootstrap and architecture diagrams, and `docs/GETTINGSTARTED.md` for a
+full walkthrough.

--- a/openwiki/envoy-generation.md
+++ b/openwiki/envoy-generation.md
@@ -1,0 +1,101 @@
+# Envoy Generation
+
+How the internal model becomes Envoy xDS protos. The entrypoint is
+`KubernetesConfigurator.Generate` (`pkg/envoy/configurator.go:119`, see
+[architecture](architecture.md)); this page covers the two layers below it:
+`ingress_translator.go` (model) and `boilerplate.go` (protos).
+
+## Intermediate model (`pkg/envoy/ingress_translator.go`)
+
+`translateIngresses` (`ingress_translator.go:462`) turns `[]*k8s.SourceRoute` into an
+`envoyConfiguration{VirtualHosts, Clusters, AccessLog}`:
+
+- **`virtualHost`** — host, timeouts, TLS key/cert, `RetryOn`, sticky-session cookie
+  fields.
+- **`cluster`** — LB hosts (with weights), health-check host/path, HTTP version,
+  timeouts, idle / max-connection-duration / max-requests-per-connection, sticky
+  `StickySessionChangeOnFailure`.
+
+`translateIngresses` groups source routes by rule host, applies Ingress-vs-HTTPRoute
+precedence and maintenance filtering (see [routing-and-policy](routing-and-policy.md)),
+dedupes upstreams (`addUpstream` — weight `0` excludes an upstream), resolves per-host
+TLS secrets when `syncSecrets`, and calls `applyRoutePolicy`
+(`ingress_translator.go:600`) — the single point where a `RoutePolicy` maps onto the
+vhost/cluster. It also maintains the `yggdrasil_upstream_info` metric with stale-label
+cleanup.
+
+## Listeners & filter chains (`configurator.go` + `boilerplate.go`)
+
+`generateListeners` (`configurator.go:194`) picks **one of three** filter-chain
+strategies, then wraps them in `makeListener`:
+
+1. **Dynamic TLS** (`syncSecrets`): one filter chain per virtual host, cert from a
+   Kubernetes Secret, SNI matched on the vhost host; a single default cert
+   (`Hosts:["*"]`) covers hosts with a missing/invalid secret.
+2. **Static TLS** (`certificates` configured): vhosts are matched to configured certs
+   (`*` wildcard per label, or global `*`), one filter chain per certificate keyed by
+   SNI `ServerNames`.
+3. **Plain HTTP**: no TLS.
+
+`makeFilterChain` (`boilerplate.go:356`) wraps the HTTP Connection Manager plus a
+`DownstreamTlsContext` (inline cert/key, ALPN, **TLS min version 1.2**) and sets
+`FilterChainMatch.ServerNames` for SNI (skipping `*`). `makeListener`
+(`boilerplate.go:418`) binds `listener_0` to the configured IPv4 address(es), adds the
+**tls_inspector** listener filter, and marks the listener `TrafficDirection_OUTBOUND`
+(needed for tracing).
+
+## The HTTP route & connection manager
+
+`makeVirtualHost` (`boilerplate.go:79`) builds a single catch-all `Prefix:"/"` route with
+a `RouteAction` (cluster, route `Timeout`, `RetryPolicy` = `RetryOn` + `PerTryTimeout`).
+Extras:
+
+- **Host reselection on retry**: when `reselectionAttempts >= 0`, adds a `previous_hosts`
+  retry-host predicate + `HostSelectionRetryMaxAttempts`.
+- **Sticky sessions**: when the vhost is sticky, attaches a per-route
+  `StatefulSessionPerRoute` with cookie-based session state.
+
+`makeConnectionManager` (`boilerplate.go:258`) assembles the HCM: a file access logger
+(JSON; see `docs/ACCESSLOG.md`), an optional gRPC access logger, the HTTP filter chain,
+optional Zipkin tracing, websocket upgrade, `UseRemoteAddress`, and
+`StripMatchingHostPort`. Routes are embedded inline (no RDS).
+
+### HTTP filter chain (`pkg/envoy/http_filters.go`)
+
+`httpFilterBuilder` composes filters and **always appends the router filter last**
+(`http_filters.go:35`). Order:
+
+```
+health_check  →  [ext_authz]  →  [stateful_session]  →  router
+```
+
+The local health filter (`makeHealthConfig`, `boilerplate.go:165`) serves Envoy's
+`/yggdrasil/status` check. `makeStatefulSessionFilter` builds the top-level
+stateful-session filter that the per-route config references.
+
+## Clusters (`makeCluster`, `boilerplate.go:518`)
+
+Each intermediate `cluster` becomes a **`STRICT_DNS`** Envoy cluster with:
+
+- inline LB endpoints + weights, connect timeout;
+- optional **upstream TLS** (via `trustCA`);
+- **health checks** (`makeHealthChecks`, `boilerplate.go:496`) — HTTP check on the
+  configured host + path;
+- **HTTP protocol options** — HTTP/1.1 vs HTTP/2 (default h2 with AllowConnect,
+  MaxConcurrentStreams 128); common options idle_timeout 60s default,
+  max_connection_duration 0, max_requests_per_connection 10000;
+- **circuit breakers** (all thresholds 32768);
+- **outlier detection** (`MaxEjectionPercent`) when `--max-ejection-percentage >= 0`;
+- **sticky-session `OverrideHostStatus`** (persist to an unhealthy backend) when
+  `StickySessionChangeOnFailure == false`.
+
+## Validation helper
+
+`ValidateEnvoyRetryOn` (`pkg/envoy/boilerplate.go`) checks retry-on values against the
+allowed set; it is also used to validate the `--retry-on` flag at startup
+(`cmd/root.go`).
+
+## Relevant tests
+
+`pkg/envoy/boilerplate_test.go`, `pkg/envoy/ingress_translator_test.go`,
+`pkg/envoy/configurator_test.go`. Run with `make test`; benchmark with `make bench`.

--- a/openwiki/kubernetes-integration.md
+++ b/openwiki/kubernetes-integration.md
@@ -1,0 +1,116 @@
+# Kubernetes Integration
+
+How Yggdrasil discovers routing across clusters and turns raw Kubernetes objects into
+`SourceRoute`s. For the resulting policy model see
+[routing-and-policy](routing-and-policy.md); for how routes become Envoy config see
+[envoy-generation](envoy-generation.md).
+
+## Multi-cluster sources
+
+Two independent mechanisms produce clusters to watch, merged in `main`
+(`cmd/root.go:206`):
+
+1. **Config-file `clusters[]`** → `createSources` (`cmd/root.go:298`). Each entry builds
+   a `rest.Config` from `apiServer` + bearer token (`token` inline or `tokenPath`) +
+   `ca`, and a `k8s.KubernetesConfig` carrying the clientset, a `maintenance` flag, a
+   `kubernetesClusterName` (metrics label), and per-cluster `gatewayClasses`.
+2. **`--kube-config` paths** → `configFromKubeConfig` (`cmd/root.go:348`). An empty path
+   means in-cluster config; otherwise `clientcmd.BuildConfigFromFlags`.
+
+Both feed `k8s.NewAggregator(sources, ctx, syncSecrets)` (`cmd/root.go:243`).
+
+## Informer selection & graceful degradation
+
+`NewAggregator` (`pkg/k8s/aggregator.go:56`) is deliberately defensive — a missing API
+group logs a warning and continues rather than failing:
+
+- **Ingress** — `getIngressInformer` (`aggregator.go:152`) probes API groups in order:
+  `networking.k8s.io/v1` → `v1beta1` → `extensions/v1beta1`, first served wins.
+- **Gateway API — opt-in per cluster** (`aggregator.go:82`): watched only when that
+  cluster has `gatewayClasses` configured **and** the server serves
+  `gateway.networking.k8s.io/v1`. It then watches `GatewayClasses`, `Gateways`,
+  `HTTPRoutes`, `ReferenceGrants`, plus core `Services` and `Namespaces`.
+- **`YggdrasilPolicy` — nested inside the Gateway block** (`aggregator.go:116`): watched
+  only if `yggdrasil.uswitch.com/v1alpha1` is served; otherwise a warning is logged and
+  "HTTPRoute policies fall back to annotations".
+- **Secrets** (`aggregator.go:132`): only when `syncSecrets`, using a dedicated factory
+  with a `type=kubernetes.io/tls` field-selector so the filter applies only to secrets.
+
+All informer callbacks emit signal-only events (see [architecture](architecture.md)).
+
+## Gateway API → `SourceRoute`
+
+`ConvertGatewayResources` (`pkg/k8s/gateway_resources.go:47`) walks each HTTPRoute ×
+configured class × matching Gateway × listener and emits a route only when both hold:
+
+- **Attachment** — `httpRouteAttachesToListener` (`gateway_resources.go:165`): parentRef
+  group/kind/name/namespace/sectionName must match, and the listener's
+  `AllowedRoutes.Namespaces` (Same / All / Selector; default Same) must permit the
+  route's namespace (`listenerAllowsRouteNamespace`).
+- **Host matching** — `matchingHTTPRouteHosts` (`gateway_resources.go:227`): intersects
+  route hostnames with the listener hostname (wildcard aware); if the route lists none,
+  it inherits the listener hostname.
+
+### Gateway address discovery (upstream resolution precedence)
+
+`resolveGatewayUpstreams` (`gateway_resources.go:262`) picks the data-plane endpoints
+for a Gateway-attached route, first match wins:
+
+1. `Gateway.status.addresses` + the listener port.
+2. A **Service owned** by the Gateway via `OwnerReference` (`isOwnedByGateway`).
+3. Static `serviceName` / `serviceNamespace` from the cluster's `gatewayClasses` config.
+
+Service-backed endpoints require a `ServicePort` equal to the listener port and pull
+ExternalIPs + LoadBalancer ingress. If nothing resolves, the route is **skipped** with a
+diagnostic (never fatal). This order matches the `docs/GETTINGSTARTED.md` "Gateway
+address discovery" section.
+
+### TLS secret resolution & cross-namespace refs
+
+`gatewayListenerTLS` (`gateway_resources.go:409`) uses **only the first**
+`CertificateRefs` entry (extra refs → diagnostic). The secret namespace defaults to the
+Gateway's namespace unless the ref specifies one. A **cross-namespace** secret ref is
+permitted only by a matching **ReferenceGrant** (`isCrossNamespaceSecretRefPermitted`,
+`gateway_resources.go:365`); non-core or grant-less refs become diagnostics and skip the
+route.
+
+Diagnostics collected during conversion are surfaced as `logrus.Warn` in
+`GetSourceRoutes` (`generic_resources.go`) — they degrade a single route, never the run.
+
+## Ingress → `SourceRoute`
+
+`convertToGenericIngress` (`generic_resources.go:77`) type-switches the three Ingress API
+versions. Upstreams come from `Status.LoadBalancer.Ingress` (hostname preferred over IP).
+TLS is a `map[host]*IngressTLS` from `Spec.TLS`, with the secret namespace = the
+Ingress's own namespace. Each route then gets `attachAnnotationPolicy`
+(`generic_resources.go:106`). Ingress class resolution: `getUsableIngressClass`
+(`generic_resources.go`) — the `kubernetes.io/ingress.class` annotation beats
+`spec.ingressClassName`.
+
+## Maintenance mode
+
+A cluster flagged `maintenance` in `clusters[]` keeps serving only where it is the
+**sole** backend: `translateIngresses` skips a maintenance cluster's upstreams for a host
+whenever a non-maintenance backend exists for that host (`hasNonMaintenance`,
+`pkg/envoy/ingress_translator.go`). Yggdrasil `Fatal`s if **all** clusters are in
+maintenance (`cmd/root.go`). Exposed via the `yggdrasil_kubernetes_cluster_in_maintenance`
+metric.
+
+## RBAC
+
+`docs/GETTINGSTARTED.md` has the full ClusterRole. In short, get/list/watch on:
+`ingresses` (extensions + networking.k8s.io); `gatewayclasses`, `gateways`, `httproutes`,
+`referencegrants` (gateway.networking.k8s.io); `yggdrasilpolicies`
+(yggdrasil.uswitch.com); `services`, `namespaces` (core); and, when `syncSecrets`,
+`secrets`.
+
+## Caveat
+
+`README.md` (line 5) links to `hack/local-gateway-test/README.md` for a local Gateway
+API test setup, but the `hack/` directory is currently **absent** from the repository.
+Treat that link as aspirational until the fixture is added.
+
+## Relevant tests
+
+`pkg/k8s/generic_resources_test.go`, `gateway_resources_test.go`,
+`gateway_policy_test.go`.

--- a/openwiki/quickstart.md
+++ b/openwiki/quickstart.md
@@ -1,0 +1,82 @@
+# Yggdrasil — Quickstart
+
+Yggdrasil is a standalone **Envoy control plane** written in Go. It watches
+Kubernetes routing resources across **one or more clusters**, converts them into a
+source-agnostic internal model, and serves Envoy xDS (v3) configuration to a fleet of
+Envoy nodes over gRPC. The result is a multi-cluster load balancer that lives
+**outside** Kubernetes — so it keeps routing even when a whole cluster is unavailable.
+
+Supported Envoy versions: **1.20.x – 1.34.x** (see `README.md`).
+
+## What it does, in one pipeline
+
+```
+Kubernetes (N clusters)                     Yggdrasil                         Envoy fleet
+┌─────────────────────────┐   watch    ┌───────────────────────────┐  ADS/xDS  ┌──────────┐
+│ Ingress                 │──────────▶ │ Aggregator  (pkg/k8s)     │           │ envoy #1 │
+│ Gateway / HTTPRoute     │            │   → []SourceRoute          │  gRPC     │ envoy #2 │
+│ Secrets (TLS)           │            │ Snapshotter (debounce 5s) │──────────▶│   ...    │
+│ YggdrasilPolicy (CRD)   │            │ Configurator → xDS snapshot│  :8080    │          │
+└─────────────────────────┘            └───────────────────────────┘           └──────────┘
+```
+
+1. **`Aggregator`** (`pkg/k8s/aggregator.go:56`) runs informers per cluster and
+   coalesces every resource change into a signal event.
+2. **`Snapshotter`** (`pkg/envoy/snapshotter.go:57`) debounces those events and, on a
+   5-second tick, pulls the current `SourceRoute`s + TLS secrets.
+3. **`Configurator`** (`pkg/envoy/configurator.go:119`) translates them into Envoy
+   Listeners + Clusters and stores a versioned snapshot in a go-control-plane cache.
+4. The **gRPC ADS/xDS server** (`cmd/server.go:55`) serves that snapshot to Envoy nodes
+   keyed by node name.
+
+## Repository layout
+
+| Path | Role |
+|------|------|
+| `main.go`, `cmd/` | CLI entrypoint, config wiring, gRPC + health HTTP servers |
+| `pkg/k8s/` | Multi-cluster watch, aggregation, Ingress + Gateway API → `SourceRoute` |
+| `pkg/policy/` | Source-agnostic `RoutePolicy` model + annotation/CRD parsers |
+| `pkg/apis/yggdrasil/v1alpha1/` | `YggdrasilPolicy` CRD Go types |
+| `pkg/client/` | Generated clientset/informers/listers for the CRD (do not hand-edit) |
+| `pkg/envoy/` | Internal model → Envoy xDS protos (listeners, clusters, filters) |
+| `deploy/crds/` | `YggdrasilPolicy` CRD manifest |
+| `docs/` | `GETTINGSTARTED.md` (install + RBAC), `ACCESSLOG.md` |
+
+## Getting started
+
+`docs/GETTINGSTARTED.md` is the hands-on walkthrough (Kubernetes RBAC, running Envoy +
+Yggdrasil, verification). Envoy nodes need only a minimal bootstrap pointing LDS/CDS at
+Yggdrasil's gRPC address; the full example lives in `README.md`. Envoy's
+`--service-node` must equal Yggdrasil's `--node-name`.
+
+Health-check your Envoy nodes at `/yggdrasil/status` — it returns 200 only once
+Yggdrasil has configured them.
+
+## Wiki map
+
+- **[Architecture](architecture.md)** — the watch → model → xDS pipeline, the
+  aggregator/snapshotter/configurator loop, and what is (and isn't) served.
+- **[Routing & policy](routing-and-policy.md)** — the domain model (Source Route,
+  Route Policy, Policy Source), Ingress-vs-HTTPRoute precedence, and how annotations
+  and the `YggdrasilPolicy` CRD combine. Canonical glossary home.
+- **[Kubernetes integration](kubernetes-integration.md)** — multi-cluster sources,
+  informer selection, Gateway API opt-in, address discovery, TLS/ReferenceGrant,
+  maintenance mode, RBAC.
+- **[Envoy generation](envoy-generation.md)** — how the internal model becomes Envoy
+  listeners, filter chains, clusters, TLS/SNI, health checks, retries, sticky sessions.
+- **[Configuration & operations](configuration.md)** — CLI flags, config file,
+  ports, metrics, build/Docker/CI, deployment model.
+
+## Where to start when changing X
+
+| You want to change… | Start in | Then check |
+|---------------------|----------|------------|
+| A traffic behavior (timeout, retry, sticky…) | `pkg/policy/` shared model | [routing-and-policy](routing-and-policy.md) |
+| How a resource is watched / discovered | `pkg/k8s/aggregator.go`, `gateway_resources.go` | [kubernetes-integration](kubernetes-integration.md) |
+| The Envoy proto output | `pkg/envoy/boilerplate.go` | [envoy-generation](envoy-generation.md) |
+| A CLI flag or config field | `cmd/root.go` | [configuration](configuration.md) |
+
+> **Convention (see `AGENTS.md`):** follow the data from Kubernetes input → internal
+> model → Envoy output, and prefer fixing the shared conversion/model layer over
+> patching a single caller. Read `CONTEXT.md` before touching routing/policy/Gateway
+> behavior — its terms are canonical across code, tests, and docs.

--- a/openwiki/routing-and-policy.md
+++ b/openwiki/routing-and-policy.md
@@ -1,0 +1,118 @@
+# Routing & Policy
+
+This page is the canonical home for Yggdrasil's routing domain model. The vocabulary is
+defined in **`CONTEXT.md`** — use those exact terms in code, tests, and PRs. This page
+explains how the model behaves; `CONTEXT.md` is the glossary of record.
+
+## Domain glossary (from `CONTEXT.md`)
+
+- **Source Route** — a Kubernetes routing input. Today: **Ingress** or **HTTPRoute**.
+- **Route Policy** — Yggdrasil's internal, source-agnostic model of traffic behavior
+  (timeouts, health checks, retries, upstream behavior, connection limits, sticky
+  sessions). This is the shared model, **not** any Kubernetes object.
+- **Policy Source** — the external representation a Route Policy is derived from. Today:
+  legacy **annotations** or the **`YggdrasilPolicy`** CRD.
+- **Effective Route Policy** — the single Route Policy applied to a Source Route after
+  precedence, fallback, and conflict resolution.
+- **YggdrasilPolicy** — the CRD (a *typed Policy Source* for HTTPRoutes). It is *not*
+  the internal Route Policy.
+
+Key relationships: a Source Route has **at most one** Effective Route Policy; a Policy
+Source produces **zero or one** Route Policy. Annotations and the CRD are **both**
+parsed into the same `RoutePolicy` model — one is never converted into the other.
+
+## The `SourceRoute` model
+
+`SourceRoute` (`pkg/k8s/generic_resources.go:15`) is the unified route produced by both
+the Ingress and Gateway paths. It carries the rule hosts, upstreams (Ingress) /
+upstream endpoints (Gateway), a per-host TLS map, a `RouteSource`
+(`generic_resources.go:42`: Kind / Namespace / Name / Class / Cluster), and the resolved
+`Policy *policy.RoutePolicy` + `PolicySource`. `GetSourceRoutes` concatenates Ingress
+routes first, then Gateway routes, across all clusters.
+
+## Ingress vs HTTPRoute precedence
+
+When an Ingress and an HTTPRoute both claim the **same host** (the migration case),
+HTTPRoute wins. This is resolved in the translator, not in `pkg/k8s`:
+
+- `sourceKindPriority` (`pkg/envoy/ingress_translator.go:655`): HTTPRoute = 1,
+  Ingress = 0.
+- `translateIngresses` (`ingress_translator.go:462`) stably sorts the per-host group by
+  that priority, so the higher-priority source's upstreams and policy take effect.
+- `classFilter` (`ingress_translator.go:248`) requires Ingresses to match a configured
+  ingress class but **always keeps** HTTPRoutes.
+
+## The two Policy Sources have different failure semantics
+
+Both produce a `RoutePolicy` (`pkg/policy/policy.go:16`), but they behave differently on
+bad input — this is intentional:
+
+| | Annotations | `YggdrasilPolicy` CRD |
+|---|---|---|
+| Parser | `ParseAnnotations` (`pkg/policy/annotations.go:16`) | `ParseSpec` (`pkg/policy/crd.go:31`) |
+| Prefix / scope | `yggdrasil.uswitch.com/*` on the object | Same-namespace HTTPRoute via `TargetRef` |
+| On invalid field | **Lenient** — skip that field, apply the rest | **Strict** — reject the *whole* policy |
+| Applies to | Ingress **and** HTTPRoute | HTTPRoute only (`ValidateTargetRef`, `crd.go:15`) |
+
+Legacy annotation quirks are preserved deliberately (e.g. an unparsable `weight`
+becomes `1`; sticky sessions require cookie name/path/ttl). Annotation keys and their
+Envoy meanings are documented in `README.md`; the annotation set is parsed in
+`annotations.go:16` and stripped from the object by `StripAnnotations`
+(`annotations.go:114`) so raw policy never rides on the shared model.
+
+CRD spec fields (`pkg/apis/yggdrasil/v1alpha1/types.go:29`): `HealthCheck`, `Timeouts`
+(default/route/perTry/cluster), `Retry.RetryOn`, `Upstream` (httpVersion "1.1"/"2",
+weight — explicit `0` excludes the upstream), `Connection`
+(idle/maxConnectionDuration/maxRequestsPerConnection), `StickySessions`. The manifest
+`deploy/crds/yggdrasil.uswitch.com_yggdrasilpolicies.yaml` enforces the enums.
+
+## How annotations and the CRD combine (HTTPRoute)
+
+`attachPolicyToSourceRoute` (`pkg/k8s/gateway_resources.go:467`) resolves an HTTPRoute's
+Effective Route Policy:
+
+1. Policies are indexed by same-namespace target (`indexPoliciesByTarget`).
+2. **Exactly one** `YggdrasilPolicy` targets the route → use it (`ParseSpec`). Invalid
+   spec → route left with **no** policy + a diagnostic. **CRD takes precedence over
+   annotations when present.**
+3. **Zero** policies target the route → **fall back** to `ParseAnnotations` on the
+   HTTPRoute's own annotations.
+4. **More than one** policy targets the same HTTPRoute → **all ignored** (fail-safe), no
+   merge, with a "duplicate YggdrasilPolicies" diagnostic.
+
+Annotations are stripped in all cases. Ingress routes never consult the CRD — they use
+`attachAnnotationPolicy` (`generic_resources.go:106`) only.
+
+## Conflicts and merging
+
+There is **no field-level merge** of policies.
+
+- **Same host, same source kind, divergent policy** → the host is *dropped* from all
+  conflicting routes with a diagnostic. `resolvePolicyConflicts`
+  (`gateway_resources.go:517`) compares `RoutePolicy.Signature()`
+  (`pkg/policy/policy.go:62`), a deterministic fingerprint that **excludes `Weight`**
+  (weight is per-upstream, not a host policy). Routes left with zero hosts are removed.
+- **Same host, different source kind** (Ingress vs HTTPRoute) → resolved by ordering
+  (last-writer-wins via `sourceKindPriority`), not by merging.
+
+## Where it lands in Envoy
+
+`applyRoutePolicy` (`pkg/envoy/ingress_translator.go:600`) is the **single place** a
+`RoutePolicy` touches Envoy output, regardless of which Policy Source produced it
+(timeouts, health-check path/host, retry-on, upstream HTTP version, connection limits,
+sticky sessions). Weight is applied separately when adding upstreams (weight `0`
+excludes an upstream). See [envoy-generation](envoy-generation.md) for the proto shapes.
+
+## Adding a new traffic-behavior field
+
+Because the model is shared, a new knob touches four places:
+
+1. Add the field to `RoutePolicy` (`pkg/policy/policy.go:16`) and, if host-relevant,
+   include it in `Signature()`.
+2. Parse it in **both** `ParseAnnotations` and `ParseSpec`.
+3. Apply it in `applyRoutePolicy` (`ingress_translator.go:600`).
+4. If it maps to a new Envoy proto field, wire it in `pkg/envoy/boilerplate.go`.
+
+Relevant tests: `pkg/policy/policy_test.go` (incl.
+`TestSignatureEquivalenceAcrossSources`), `pkg/k8s/gateway_policy_test.go`,
+`pkg/envoy/ingress_translator_test.go`.


### PR DESCRIPTION
## Contexte

Génération initiale de la documentation wiki OpenWiki (`/openwiki:wiki init`) sous `openwiki/`, ciblée sur la branche `feat/integrates-gw-api` (intégration Gateway API + CRD YggdrasilPolicy).

## Contenu

- `openwiki/quickstart.md` — entrypoint : pipeline, layout du repo, navigation
- `openwiki/architecture.md` — watch → modèle interne → xDS ; aggregator / snapshotter / configurator ; LDS+CDS seulement, routes inline, STRICT_DNS
- `openwiki/routing-and-policy.md` — glossaire (CONTEXT.md) ; précédence Ingress/HTTPRoute ; annotations vs CRD YggdrasilPolicy ; conflits
- `openwiki/kubernetes-integration.md` — multi-cluster, informers, Gateway API opt-in, address discovery, TLS/ReferenceGrant, maintenance, RBAC
- `openwiki/envoy-generation.md` — listeners, filter chains, clusters, TLS/SNI, health checks, retries, sticky sessions
- `openwiki/configuration.md` — flags CLI, config file, ports, metrics, build/Docker/CI, déploiement
- Section `## OpenWiki` ajoutée à `AGENTS.md`
- `openwiki/.last-update.json`

Tout est ancré dans le code (`file:line`), aucune invention. Aucune modification hors `openwiki/` + `AGENTS.md`.

## Caveat

`README.md:5` référence `hack/local-gateway-test/README.md`, absent du repo — signalé dans `kubernetes-integration.md`.